### PR TITLE
docs: remove milliseconds from DateTime docs

### DIFF
--- a/02-documentation/concepts/schemas.md
+++ b/02-documentation/concepts/schemas.md
@@ -87,7 +87,7 @@ Booleans have only 2 states: True or false, yes or no, 1 or 0.
 
 ![DateTime](../../.gitbook/assets/datetime.png)
 
-Date and time in the ISO8601 standard. The format is: `YYYY-MM-DDTHH:mm:ss.sssZ`.
+Date and time in the ISO8601 standard. The format is: `YYYY-MM-DDTHH:mm:ssZ`.
 
 #### API representation
 


### PR DESCRIPTION
The reply to the following support ticket https://support.squidex.io/t/support-iso-8601-missing-miliseconds/2191 surfaced an inconsistency on the documentation around DateTime.