### PR TITLE
Fixed error in sidebar code example.

### DIFF
--- a/02-documentation/developer-guides/custom-sidebars.md
+++ b/02-documentation/developer-guides/custom-sidebars.md
@@ -39,7 +39,7 @@ You create a very simple HTML page and then you reference the editor SDK. In you
 
 <body>
     <textarea name="content" id="content"></textarea>
-    <textarea name="context" id="contexttor"></textarea>
+    <textarea name="context" id="context"></textarea>
 
     <script>
         var contentElement = document.getElementById('content');


### PR DESCRIPTION
Fixed the ID of the "context" text area in the example.